### PR TITLE
Moved webpack to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,14 +28,12 @@
     "three": "*",
     "three-orbit-controls": "^72.0.0",
     "ts-loader": "^2.0.0",
-    "typescript": "^2.1.6"
+    "typescript": "^2.1.6",
+    "webpack": "^2.2.0-rc.2",
+    "webpack-dev-server": "^2.2.0-rc.0"
   },
   "peerDependencies": {
     "three": "*",
     "@types/three": "*"
-  },
-  "dependencies": {
-    "webpack": "^2.2.0-rc.2",
-    "webpack-dev-server": "^2.2.0-rc.0"
   }
 }


### PR DESCRIPTION
When used as a non-dev dependency this breaks other libraries that a different version of webpack [create-react-app](https://github.com/facebookincubator/create-react-app) (it causes this error https://github.com/facebookincubator/create-react-app/issues/2023)