### PR TITLE
Fix broken type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/three": "^0.91.7",
+    "@types/three": "^0.93.15",
     "three": "*",
     "three-orbit-controls": "^72.0.0",
     "ts-loader": "^2.0.0",

--- a/src/SpriteText2D.ts
+++ b/src/SpriteText2D.ts
@@ -31,7 +31,6 @@ export class SpriteText2D extends Text2D{
 
     if (!this.sprite) {
       this.sprite = new THREE.Sprite( this.material )
-      this.geometry = this.sprite.geometry
       this.add(this.sprite)
     }
 

--- a/src/Text2D.ts
+++ b/src/Text2D.ts
@@ -32,7 +32,6 @@ export abstract class Text2D extends THREE.Object3D {
   protected _shadowOffsetY: number;
 
   protected canvas: CanvasText;
-  protected geometry: THREE.Geometry | THREE.BufferGeometry;
 
   constructor(text = '', options: TextOptions = {}) {
     super();


### PR DESCRIPTION
My first attempt to build this failed. it was caused by the new typescript version being incompatible with old three.js type definition, so I updated it.
The new type definition had removed `THREE.Sprite.geometry`. since it wasn't doing any good here, I simply removed it.