### PR TITLE
Use Sprite.center property for aligning sprites

### DIFF
--- a/src/SpriteText2D.ts
+++ b/src/SpriteText2D.ts
@@ -37,8 +37,17 @@ export class SpriteText2D extends Text2D{
 
     this.sprite.scale.set(this.canvas.width, this.canvas.height, 1)
 
-    this.sprite.position.x = ((this.canvas.width/2) - (this.canvas.textWidth/2)) + ((this.canvas.textWidth/2) * this.align.x)
-    this.sprite.position.y = (- this.canvas.height/2) + ((this.canvas.textHeight/2) * this.align.y)
+    this.updateAlign();
+  }
+
+  updateAlign() {
+    this.sprite.center.x = this._align.x * this.canvas.textWidth / this.canvas.width;
+    this.sprite.center.y = 1 - (1 - this._align.y) * this.canvas.textHeight / this.canvas.height;
+  }
+
+  set align(value: THREE.Vector2) {
+    this._align = value;
+    this.updateAlign();
   }
 
 }

--- a/src/SpriteText2D.ts
+++ b/src/SpriteText2D.ts
@@ -47,6 +47,8 @@ export class SpriteText2D extends Text2D{
 
   set align(value: THREE.Vector2) {
     this._align = value;
+    this._align.multiplyScalar(0.5);
+    this._align.addScalar(0.5);
     this.updateAlign();
   }
 

--- a/src/SpriteText2D.ts
+++ b/src/SpriteText2D.ts
@@ -41,8 +41,10 @@ export class SpriteText2D extends Text2D{
   }
 
   updateAlign() {
-    this.sprite.center.x = this._align.x * this.canvas.textWidth / this.canvas.width;
-    this.sprite.center.y = 1 - (1 - this._align.y) * this.canvas.textHeight / this.canvas.height;
+    if (this.sprite) {
+      this.sprite.center.x = this._align.x * this.canvas.textWidth / this.canvas.width;
+      this.sprite.center.y = 1 - (1 - this._align.y) * this.canvas.textHeight / this.canvas.height;
+    }
   }
 
   set align(value: THREE.Vector2) {

--- a/src/SpriteText2D.ts
+++ b/src/SpriteText2D.ts
@@ -46,7 +46,7 @@ export class SpriteText2D extends Text2D{
   }
 
   set align(value: THREE.Vector2) {
-    this._align = value;
+    this._align.copy(value);
     this._align.multiplyScalar(0.5);
     this._align.addScalar(0.5);
     this.updateAlign();

--- a/src/Text2D.ts
+++ b/src/Text2D.ts
@@ -17,12 +17,12 @@ export interface TextOptions {
 
 export abstract class Text2D extends THREE.Object3D {
 
-  public align: THREE.Vector2;
   public side: number;
   public antialias: boolean;
   public texture: THREE.Texture;
   public material: THREE.MeshBasicMaterial | THREE.SpriteMaterial;
 
+  protected _align: THREE.Vector2;
   protected _font: string;
   protected _fillStyle: string;
   protected _text: string;
@@ -86,6 +86,14 @@ export abstract class Text2D extends THREE.Object3D {
       this._fillStyle = value;
       this.updateText();
     }
+  }
+
+  get align() {
+    return this._align;
+  }
+
+  set align(value: THREE.Vector2) {
+    this._align = value;
   }
 
   cleanUp () {

--- a/src/Text2D.ts
+++ b/src/Text2D.ts
@@ -37,6 +37,7 @@ export abstract class Text2D extends THREE.Object3D {
   constructor(text = '', options: TextOptions = {}) {
     super();
 
+    this._align = new THREE.Vector2();
     this._font = options.font || '30px Arial';
     this._fillStyle = options.fillStyle || '#FFFFFF';
 
@@ -93,7 +94,7 @@ export abstract class Text2D extends THREE.Object3D {
   }
 
   set align(value: THREE.Vector2) {
-    this._align = value;
+    this._align.copy(value);
   }
 
   cleanUp () {


### PR DESCRIPTION
Sorry for spamming PRs. This will be the last. This change will work the same way as #18, but I noticed that three had introduced new `Sprite.center` property.
three itself have got this property anyway, so there's virtually no performance cost for supporting it.