### PR TITLE
support for background and padding

### DIFF
--- a/src/CanvasText.ts
+++ b/src/CanvasText.ts
@@ -31,12 +31,17 @@ export class CanvasText {
     this.textHeight = lineHeight + lineHeight * ctxOptions.lineHeight * (lines.length - 1);
 
     // 2 = prevent canvas being 0 size when using empty / null text
-    this.canvas.width = Math.max(2, THREE.Math.ceilPowerOfTwo(this.textWidth));
-    this.canvas.height = Math.max(2, THREE.Math.ceilPowerOfTwo(this.textHeight));
+    this.canvas.width = Math.max(2, THREE.Math.ceilPowerOfTwo(this.textWidth + (2 * ctxOptions.horizontalPadding)));
+    this.canvas.height = Math.max(2, THREE.Math.ceilPowerOfTwo(this.textHeight + (2 * ctxOptions.verticalPadding)));
 
     this.ctx.font = ctxOptions.font
 
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    if (ctxOptions.backgroundColor) {
+      this.ctx.fillStyle = ctxOptions.backgroundColor;
+      this.ctx.fillRect(0, 0, this.textWidth + (2 * ctxOptions.horizontalPadding), this.textHeight + (2 * ctxOptions.verticalPadding));
+    }
 
     this.ctx.fillStyle = ctxOptions.fillStyle
     if (ctxOptions.align.x === 1) this.ctx.textAlign = 'left';
@@ -49,8 +54,9 @@ export class CanvasText {
     this.ctx.shadowOffsetY = ctxOptions.shadowOffsetY;
 
     const x = this.textWidth * (0.5 - ctxOptions.align.x * 0.5);
+    const y = 0.5 * ((lineHeight * ctxOptions.lineHeight) - lineHeight);
     for (let i = 0; i < lines.length; i++) {
-      this.ctx.fillText(lines[i], x, lineHeight * ctxOptions.lineHeight * i);
+      this.ctx.fillText(lines[i], x + ctxOptions.horizontalPadding, (lineHeight * ctxOptions.lineHeight * i) + ctxOptions.verticalPadding + y);
     }
     return this.canvas
   }

--- a/src/MeshText2D.ts
+++ b/src/MeshText2D.ts
@@ -26,7 +26,10 @@ export class MeshText2D extends Text2D {
       shadowOffsetX: this._shadowOffsetX,
       shadowOffsetY: this._shadowOffsetY,
       lineHeight: this._lineHeight,
-      align: this.align
+      align: this.align,
+      backgroundColor: this._backgroundColor,
+      horizontalPadding: this._horizontalPadding,
+      verticalPadding: this._verticalPadding
     })
 
     this.texture = new THREE.Texture(this.canvas.canvas);

--- a/src/SpriteText2D.ts
+++ b/src/SpriteText2D.ts
@@ -19,7 +19,10 @@ export class SpriteText2D extends Text2D{
       shadowOffsetX: this._shadowOffsetX,
       shadowOffsetY: this._shadowOffsetY,
       lineHeight: this._lineHeight,
-      align: this.align
+      align: this.align,
+      backgroundColor: this._backgroundColor,
+      horizontalPadding: this._horizontalPadding,
+      verticalPadding: this._verticalPadding
     })
 
     // cleanup previous texture

--- a/src/Text2D.ts
+++ b/src/Text2D.ts
@@ -14,6 +14,9 @@ export interface TextOptions {
   shadowOffsetX?: number;
   shadowOffsetY?: number;
   lineHeight?: number;
+  backgroundColor?: string;
+  horizontalPadding?: number;
+  verticalPadding?: number;
 }
 
 export abstract class Text2D extends THREE.Object3D {
@@ -32,6 +35,9 @@ export abstract class Text2D extends THREE.Object3D {
   protected _shadowOffsetX: number;
   protected _shadowOffsetY: number;
   protected _lineHeight: number;
+  protected _backgroundColor: string;
+  protected _horizontalPadding: number;
+  protected _verticalPadding: number;
 
   protected canvas: CanvasText;
 
@@ -47,6 +53,10 @@ export abstract class Text2D extends THREE.Object3D {
     this._shadowOffsetX = options.shadowOffsetX || 0;
     this._shadowOffsetY = options.shadowOffsetY || 0;
     this._lineHeight = options.lineHeight || 1.2;
+
+    this._backgroundColor = options.backgroundColor || 'transparent';
+    this._horizontalPadding = options.horizontalPadding || 0;
+    this._verticalPadding = options.verticalPadding || 0;
 
     this.canvas = new CanvasText()
 


### PR DESCRIPTION
Fixes #2 by adding 

```
backgroundColor?: string;
horizontalPadding?: number;
verticalPadding?: number;  
```

properties to the `TextOptions` interface and apply it in `CanvasText` using a `fillRect`